### PR TITLE
divide by the product of scaling

### DIFF
--- a/models/PDCNet/base_pdcnet.py
+++ b/models/PDCNet/base_pdcnet.py
@@ -408,7 +408,7 @@ class UncertaintyPredictionInference(nn.Module):
             if ratio == 1.0:
                 list_of_H_target.append(np.eye(3))
                 list_of_H_source.append(np.eye(3))
-                list_of_normalization_value.append(float(h_t * w_t / scaling[0] * scaling[1]))
+                list_of_normalization_value.append(float(h_t * w_t / (scaling[0] * scaling[1])))
                 list_of_padded_target_images.append(np.expand_dims(image_target_original_padded, 0))
                 list_of_padded_source_images.append(np.expand_dims(image_source_original_padded, 0))
             elif ratio < 1.0:
@@ -419,7 +419,7 @@ class UncertaintyPredictionInference(nn.Module):
                 H_target_resized = np.array([[ratio_w, 0, 0], [0, ratio_h, 0], [0, 0, 1]])
                 list_of_H_target.append(H_target_resized)
                 list_of_H_source.append(np.eye(3))
-                list_of_normalization_value.append(float(w_resized * h_resized / scaling[0] * scaling[1]))
+                list_of_normalization_value.append(float(w_resized * h_resized / (scaling[0] * scaling[1])))
 
                 image_target_resized = cv2.warpPerspective(image_target_original_padded, H_target_resized,
                                                            (w_resized, h_resized))
@@ -436,7 +436,7 @@ class UncertaintyPredictionInference(nn.Module):
                 H_source_resized = np.array([[ratio_w, 0, 0], [0, ratio_h, 0], [0, 0, 1]])
                 list_of_H_source.append(H_source_resized)
                 list_of_H_target.append(np.eye(3))
-                list_of_normalization_value.append(float(h_t * w_t / scaling[0] * scaling[1]))
+                list_of_normalization_value.append(float(h_t * w_t / (scaling[0] * scaling[1])))
 
                 image_source_resized = cv2.warpPerspective(image_source_original_padded, H_source_resized,
                                                            (w_resized, h_resized))


### PR DESCRIPTION
should this divide by the quantity `(scaling[0] * scaling[1])` (instead of just scaling[0] and then multiplying by scaling[1])? I don't think this changes the relative order of list_inliers though because the three places where list_of_normalization_value is computed all do the same thing and list_of_normalization_value is just a normalization constant when computing list_inliers